### PR TITLE
Add offline sandbox for thermostat card

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,21 @@ A simple thermostat implemented in CSS and SVG based on <a href="https://codepen
 ## Preview
 ![](https://bbs.hassbian.com/data/attachment/forum/202003/14/172544q3ajp7742cbo757h.gif)
 
+## Offline sandbox
+
+An offline test harness is available in [`sandbox/index.html`](./sandbox/index.html). Download or
+clone this repository and open that file directly in any modern browser to experiment with the
+thermostat card without Home Assistant.
+
+The sandbox provides:
+
+- A mocked Home Assistant API with adjustable entity attributes
+- Service-call logging so you can see what the card is sending back to Home Assistant
+- Real-time controls for HVAC mode, target temperatures, presets, and more
+
+Every change you make in the control panel is reflected immediately on the card so you can validate
+its behaviour visually.
+
 ## Update
 ### v1.3.0
 + fix icon

--- a/sandbox/app.js
+++ b/sandbox/app.js
@@ -1,0 +1,278 @@
+import '../dist/main.js?v=1.3.0';
+import { createMockHass, DEFAULT_CLIMATE_ENTITY } from './mock-hass.js';
+
+const ALL_HVAC_MODES = ['off', 'heat', 'cool', 'heat_cool', 'auto', 'dry', 'fan_only'];
+
+const ICON_SYMBOLS = {
+  'mdi:dots-vertical': '⋮',
+  'mdi:dots-horizontal': '⋯',
+  'mdi:water-percent': '💧',
+  'mdi:fan': '🌀',
+  'mdi:snowflake': '❄️',
+  'mdi:fire': '🔥',
+  'mdi:sync': '🔁',
+  'mdi:atom': '⚛️',
+  'mdi:power': '⏻',
+  'mdi:thermometer': '🌡️',
+  'mdi:help': '?',
+};
+
+function registerHaIcon() {
+  if (customElements.get('ha-icon')) return;
+  class HaIcon extends HTMLElement {
+    static get observedAttributes() {
+      return ['icon'];
+    }
+    connectedCallback() {
+      this._render();
+    }
+    attributeChangedCallback() {
+      this._render();
+    }
+    _render() {
+      const icon = this.getAttribute('icon') || '';
+      const symbol = ICON_SYMBOLS[icon] || icon.replace('mdi:', '') || '•';
+      this.textContent = symbol;
+      this.setAttribute('role', 'img');
+      this.setAttribute('aria-label', icon.replace('mdi:', '').replace(/[-_]/g, ' '));
+    }
+  }
+  customElements.define('ha-icon', HaIcon);
+}
+
+function registerHaIconButton() {
+  if (customElements.get('ha-icon-button')) return;
+  class HaIconButton extends HTMLElement {
+    static get observedAttributes() {
+      return ['icon'];
+    }
+    connectedCallback() {
+      this.setAttribute('role', this.getAttribute('role') || 'button');
+      if (!this.hasAttribute('tabindex')) {
+        this.setAttribute('tabindex', '0');
+      }
+      this._render();
+      this.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          this.click();
+        }
+      });
+    }
+    attributeChangedCallback() {
+      this._render();
+    }
+    _render() {
+      const icon = this.getAttribute('icon') || '';
+      const symbol = ICON_SYMBOLS[icon] || icon.replace('mdi:', '') || '•';
+      this.innerHTML = `<span aria-hidden="true">${symbol}</span>`;
+    }
+  }
+  customElements.define('ha-icon-button', HaIconButton);
+}
+
+registerHaIcon();
+registerHaIconButton();
+
+const hass = createMockHass();
+const card = document.querySelector('#thermostat-card');
+
+const cardConfig = {
+  entity: DEFAULT_CLIMATE_ENTITY,
+  name: 'Mock Thermostat',
+  highlight_tap: true,
+  pending: 1,
+};
+
+card.setConfig(cardConfig);
+card.hass = hass;
+
+const form = document.querySelector('#climate-form');
+const hvacStateSelect = document.querySelector('#hvac-state');
+const ambientInput = document.querySelector('#ambient-temp');
+const targetInput = document.querySelector('#target-temp');
+const targetLowInput = document.querySelector('#target-temp-low');
+const targetHighInput = document.querySelector('#target-temp-high');
+const minInput = document.querySelector('#min-temp');
+const maxInput = document.querySelector('#max-temp');
+const presetSelect = document.querySelector('#preset-mode');
+const awayCheckbox = document.querySelector('#away-mode');
+const hvacModesContainer = document.querySelector('#hvac-modes');
+const serviceLogList = document.querySelector('#service-log');
+const stateViewer = document.querySelector('#state-json');
+const dualStateLabel = document.querySelector('#dual-state');
+const resetButton = document.querySelector('#reset-state');
+
+const hvacModeInputs = ALL_HVAC_MODES.map((mode) => {
+  const label = document.createElement('label');
+  label.className = 'chip';
+
+  const input = document.createElement('input');
+  input.type = 'checkbox';
+  input.name = 'hvac-mode';
+  input.value = mode;
+
+  const span = document.createElement('span');
+  span.textContent = mode;
+
+  label.appendChild(input);
+  label.appendChild(span);
+  hvacModesContainer.appendChild(label);
+
+  input.addEventListener('change', () => {
+    const selectedModes = hvacModeInputs
+      .filter((item) => item.checked)
+      .map((item) => item.value);
+    hass.updateEntity(DEFAULT_CLIMATE_ENTITY, {
+      attributes: { hvac_modes: selectedModes },
+    });
+  });
+
+  return input;
+});
+
+function parseNumber(value) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+}
+
+function formatNumber(value) {
+  return typeof value === 'number' && Number.isFinite(value) ? value : '';
+}
+
+function updateForm() {
+  const climate = hass.states[DEFAULT_CLIMATE_ENTITY];
+  if (!climate) return;
+
+  const attrs = climate.attributes || {};
+  const isDual =
+    typeof attrs.target_temp_low === 'number' &&
+    typeof attrs.target_temp_high === 'number' &&
+    attrs.target_temp_low !== attrs.target_temp_high;
+
+  hvacStateSelect.value = climate.state || 'off';
+  ambientInput.value = formatNumber(attrs.current_temperature);
+  targetInput.value = formatNumber(attrs.temperature);
+  targetInput.disabled = isDual;
+  targetLowInput.value = formatNumber(attrs.target_temp_low);
+  targetHighInput.value = formatNumber(attrs.target_temp_high);
+  minInput.value = formatNumber(attrs.min_temp);
+  maxInput.value = formatNumber(attrs.max_temp);
+  presetSelect.value = attrs.preset_mode || 'none';
+  awayCheckbox.checked = attrs.away_mode === 'on';
+
+  hvacModeInputs.forEach((input) => {
+    input.checked = Array.isArray(attrs.hvac_modes)
+      ? attrs.hvac_modes.includes(input.value)
+      : false;
+  });
+
+  dualStateLabel.textContent = isDual
+    ? 'Dual set-point mode (heat/cool) is active.'
+    : 'Single set-point mode is active.';
+
+  targetInput.parentElement.dataset.disabled = isDual ? 'true' : 'false';
+
+  stateViewer.textContent = JSON.stringify(climate, null, 2);
+}
+
+function renderServiceLog() {
+  serviceLogList.innerHTML = '';
+  const entries = hass.serviceLog;
+
+  if (!entries.length) {
+    const item = document.createElement('li');
+    item.className = 'empty';
+    item.textContent = 'No service calls yet.';
+    serviceLogList.appendChild(item);
+    return;
+  }
+
+  entries.forEach((entry) => {
+    const item = document.createElement('li');
+    const time = new Date(entry.timestamp).toLocaleTimeString();
+    const summary = document.createElement('div');
+    summary.className = 'summary';
+    summary.innerHTML = `<code>${entry.domain}.${entry.service}</code> <time>${time}</time>`;
+
+    const payload = document.createElement('pre');
+    payload.textContent = JSON.stringify(entry.data, null, 2);
+
+    item.appendChild(summary);
+    item.appendChild(payload);
+    serviceLogList.appendChild(item);
+  });
+}
+
+function refresh() {
+  card.hass = hass;
+  updateForm();
+  renderServiceLog();
+}
+
+hass.subscribe(refresh);
+refresh();
+
+hvacStateSelect.addEventListener('change', (event) => {
+  hass.updateEntity(DEFAULT_CLIMATE_ENTITY, { state: event.target.value });
+});
+
+ambientInput.addEventListener('change', (event) => {
+  hass.updateEntity(DEFAULT_CLIMATE_ENTITY, {
+    attributes: { current_temperature: parseNumber(event.target.value) },
+  });
+});
+
+targetInput.addEventListener('change', (event) => {
+  const value = parseNumber(event.target.value);
+  if (value === null) return;
+  hass.updateEntity(DEFAULT_CLIMATE_ENTITY, {
+    attributes: {
+      temperature: value,
+      target_temp_low: value,
+      target_temp_high: value,
+    },
+  });
+});
+
+targetLowInput.addEventListener('change', (event) => {
+  hass.updateEntity(DEFAULT_CLIMATE_ENTITY, {
+    attributes: { target_temp_low: parseNumber(event.target.value) },
+  });
+});
+
+targetHighInput.addEventListener('change', (event) => {
+  hass.updateEntity(DEFAULT_CLIMATE_ENTITY, {
+    attributes: { target_temp_high: parseNumber(event.target.value) },
+  });
+});
+
+minInput.addEventListener('change', (event) => {
+  hass.updateEntity(DEFAULT_CLIMATE_ENTITY, {
+    attributes: { min_temp: parseNumber(event.target.value) },
+  });
+});
+
+maxInput.addEventListener('change', (event) => {
+  hass.updateEntity(DEFAULT_CLIMATE_ENTITY, {
+    attributes: { max_temp: parseNumber(event.target.value) },
+  });
+});
+
+presetSelect.addEventListener('change', (event) => {
+  hass.updateEntity(DEFAULT_CLIMATE_ENTITY, {
+    attributes: { preset_mode: event.target.value },
+  });
+});
+
+awayCheckbox.addEventListener('change', (event) => {
+  hass.updateEntity(DEFAULT_CLIMATE_ENTITY, {
+    attributes: { away_mode: event.target.checked ? 'on' : 'off' },
+  });
+});
+
+resetButton.addEventListener('click', () => {
+  hass.reset();
+});
+
+form.addEventListener('submit', (event) => event.preventDefault());

--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -1,0 +1,425 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Thermostat Card Sandbox</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        --background: #0f172a;
+        --panel: #111827;
+        --panel-alt: #1f2937;
+        --accent: #38bdf8;
+        --accent-strong: #0ea5e9;
+        --text: #e2e8f0;
+        --text-muted: #94a3b8;
+        --border: rgba(148, 163, 184, 0.25);
+        font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont,
+          'Helvetica Neue', sans-serif;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background: radial-gradient(circle at top, rgba(56, 189, 248, 0.15), transparent 55%),
+          var(--background);
+        color: var(--text);
+        display: flex;
+        flex-direction: column;
+        padding: 2.5rem 1.5rem 2rem;
+        gap: 2rem;
+      }
+
+      header {
+        max-width: 1100px;
+        margin: 0 auto;
+        text-align: center;
+      }
+
+      header h1 {
+        margin: 0 0 0.5rem;
+        font-size: clamp(1.8rem, 3vw, 2.4rem);
+      }
+
+      header p {
+        margin: 0 auto;
+        max-width: 680px;
+        font-size: 1rem;
+        line-height: 1.5;
+        color: var(--text-muted);
+      }
+
+      main {
+        max-width: 1100px;
+        width: 100%;
+        margin: 0 auto;
+        display: grid;
+        gap: 1.75rem;
+      }
+
+      @media (min-width: 960px) {
+        main {
+          grid-template-columns: 1fr 1fr;
+          align-items: start;
+        }
+      }
+
+      section.card-panel,
+      section.control-panel {
+        background: linear-gradient(160deg, rgba(15, 23, 42, 0.9), rgba(30, 41, 59, 0.9));
+        border: 1px solid var(--border);
+        border-radius: 24px;
+        padding: 1.75rem;
+        box-shadow: 0 20px 60px rgba(15, 23, 42, 0.45);
+      }
+
+      section.card-panel h2,
+      section.control-panel h2,
+      section.control-panel h3 {
+        margin: 0 0 1rem;
+        font-size: 1.3rem;
+      }
+
+      .card-wrapper {
+        display: flex;
+        justify-content: center;
+        padding: 1rem 0;
+      }
+
+      thermostat-card {
+        display: block;
+        max-width: 420px;
+        width: min(100%, 420px);
+      }
+
+      ha-card {
+        display: block;
+        background: radial-gradient(circle at top left, rgba(56, 189, 248, 0.18), transparent 65%),
+          var(--panel-alt);
+        border-radius: 28px;
+        overflow: hidden;
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        box-shadow: 0 12px 40px rgba(8, 47, 73, 0.55);
+      }
+
+      .card-info {
+        margin-top: 1rem;
+        padding: 1rem;
+        border-radius: 16px;
+        background: rgba(148, 163, 184, 0.1);
+        color: var(--text-muted);
+        font-size: 0.95rem;
+        line-height: 1.5;
+      }
+
+      .card-actions {
+        margin-top: 1.5rem;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        align-items: center;
+        justify-content: space-between;
+      }
+
+      .card-actions button {
+        border: none;
+        border-radius: 999px;
+        padding: 0.6rem 1.2rem;
+        font-size: 0.95rem;
+        font-weight: 600;
+        color: var(--background);
+        background: linear-gradient(120deg, var(--accent), var(--accent-strong));
+        cursor: pointer;
+        box-shadow: 0 12px 30px rgba(14, 165, 233, 0.35);
+        transition: transform 160ms ease, box-shadow 160ms ease;
+      }
+
+      .card-actions button:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 16px 40px rgba(14, 165, 233, 0.4);
+      }
+
+      .card-actions span {
+        color: var(--text-muted);
+        font-size: 0.95rem;
+      }
+
+      form {
+        display: grid;
+        gap: 1rem;
+      }
+
+      .field {
+        display: grid;
+        gap: 0.35rem;
+      }
+
+      .field label,
+      .field .label {
+        font-weight: 600;
+        font-size: 0.95rem;
+        color: var(--text);
+      }
+
+      .field label span {
+        color: var(--text-muted);
+        font-weight: 400;
+        margin-left: 0.35rem;
+      }
+
+      .field input[type='number'],
+      .field select {
+        width: 100%;
+        border-radius: 12px;
+        border: 1px solid rgba(148, 163, 184, 0.25);
+        background: rgba(15, 23, 42, 0.6);
+        color: var(--text);
+        padding: 0.65rem 0.75rem;
+        font-size: 1rem;
+        transition: border 160ms ease, box-shadow 160ms ease;
+      }
+
+      .field input[type='number']:focus,
+      .field select:focus {
+        outline: none;
+        border-color: var(--accent);
+        box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.25);
+      }
+
+      .field[data-disabled='true'] {
+        opacity: 0.6;
+      }
+
+      .field input[type='checkbox'] {
+        width: 18px;
+        height: 18px;
+        margin-right: 0.4rem;
+      }
+
+      .chip-group {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+      }
+
+      .chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        padding: 0.4rem 0.75rem;
+        border-radius: 999px;
+        border: 1px solid rgba(148, 163, 184, 0.25);
+        background: rgba(15, 23, 42, 0.45);
+        font-size: 0.9rem;
+      }
+
+      .chip input {
+        accent-color: var(--accent-strong);
+      }
+
+      #service-log {
+        list-style: none;
+        margin: 1rem 0 0;
+        padding: 0;
+        display: grid;
+        gap: 0.75rem;
+      }
+
+      #service-log li {
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        border-radius: 16px;
+        padding: 0.75rem 1rem;
+        background: rgba(15, 23, 42, 0.65);
+      }
+
+      #service-log li .summary {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        gap: 0.5rem;
+        margin-bottom: 0.35rem;
+      }
+
+      #service-log li code {
+        font-family: 'JetBrains Mono', 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco,
+          Consolas, 'Liberation Mono', 'Courier New', monospace;
+        font-size: 0.9rem;
+        background: rgba(56, 189, 248, 0.12);
+        padding: 0.15rem 0.4rem;
+        border-radius: 6px;
+        color: var(--accent);
+      }
+
+      #service-log li time {
+        color: var(--text-muted);
+        font-size: 0.85rem;
+      }
+
+      #service-log li pre {
+        margin: 0;
+        font-size: 0.85rem;
+        line-height: 1.45;
+        white-space: pre-wrap;
+        word-break: break-word;
+      }
+
+      #service-log li.empty {
+        text-align: center;
+        border-style: dashed;
+        color: var(--text-muted);
+      }
+
+      .state-viewer {
+        margin-top: 1.5rem;
+      }
+
+      .state-viewer pre {
+        margin: 0;
+        padding: 1rem;
+        border-radius: 16px;
+        background: rgba(15, 23, 42, 0.7);
+        border: 1px solid rgba(148, 163, 184, 0.25);
+        font-size: 0.85rem;
+        line-height: 1.45;
+        max-height: 260px;
+        overflow: auto;
+      }
+
+      ha-icon,
+      ha-icon-button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 1.1rem;
+        width: 32px;
+        height: 32px;
+        border-radius: 50%;
+        background: rgba(148, 163, 184, 0.15);
+        color: var(--text);
+      }
+
+      ha-icon-button {
+        cursor: pointer;
+        transition: background 160ms ease, transform 160ms ease;
+      }
+
+      ha-icon-button:hover,
+      ha-icon-button:focus {
+        background: rgba(56, 189, 248, 0.2);
+        transform: translateY(-1px);
+        outline: none;
+      }
+
+      footer {
+        text-align: center;
+        color: var(--text-muted);
+        font-size: 0.85rem;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Thermostat Card Sandbox</h1>
+      <p>
+        Use this offline page to experiment with the Lovelace Thermostat Card. The controls on the
+        right emulate the Home Assistant API and allow you to tweak entity data, call services, and
+        observe how the card reacts in real time.
+      </p>
+    </header>
+    <main>
+      <section class="card-panel">
+        <h2>Card preview</h2>
+        <div class="card-wrapper">
+          <thermostat-card id="thermostat-card"></thermostat-card>
+        </div>
+        <div class="card-info">
+          The mock Home Assistant instance mirrors service calls made by the card, so dragging the
+          dial or choosing a HVAC mode will immediately update the simulated entity and log the
+          request below.
+        </div>
+        <div class="card-actions">
+          <span id="dual-state">Single set-point mode is active.</span>
+          <button type="button" id="reset-state">Reset mock state</button>
+        </div>
+      </section>
+      <section class="control-panel">
+        <h2>Mock climate entity</h2>
+        <form id="climate-form">
+          <div class="field">
+            <label for="hvac-state">HVAC state</label>
+            <select id="hvac-state">
+              <option value="off">off</option>
+              <option value="heat">heat</option>
+              <option value="cool">cool</option>
+              <option value="heat_cool">heat_cool</option>
+              <option value="auto">auto</option>
+              <option value="dry">dry</option>
+              <option value="fan_only">fan_only</option>
+            </select>
+          </div>
+          <div class="field">
+            <label for="ambient-temp">Ambient temperature <span>(°C)</span></label>
+            <input id="ambient-temp" type="number" step="0.1" min="-20" max="50" />
+          </div>
+          <div class="field" data-disabled="false">
+            <label for="target-temp">Target temperature <span>(°C)</span></label>
+            <input id="target-temp" type="number" step="0.1" min="-20" max="50" />
+          </div>
+          <div class="field">
+            <label for="target-temp-low">Target low <span>(°C)</span></label>
+            <input id="target-temp-low" type="number" step="0.1" min="-20" max="50" />
+          </div>
+          <div class="field">
+            <label for="target-temp-high">Target high <span>(°C)</span></label>
+            <input id="target-temp-high" type="number" step="0.1" min="-20" max="50" />
+          </div>
+          <div class="field">
+            <label for="min-temp">Minimum temperature <span>(°C)</span></label>
+            <input id="min-temp" type="number" step="0.5" min="-40" max="60" />
+          </div>
+          <div class="field">
+            <label for="max-temp">Maximum temperature <span>(°C)</span></label>
+            <input id="max-temp" type="number" step="0.5" min="-40" max="60" />
+          </div>
+          <div class="field">
+            <label for="preset-mode">Preset mode</label>
+            <select id="preset-mode">
+              <option value="none">none</option>
+              <option value="home">home</option>
+              <option value="away">away</option>
+              <option value="sleep">sleep</option>
+              <option value="eco">eco</option>
+            </select>
+          </div>
+          <div class="field">
+            <label class="label">Available HVAC modes</label>
+            <div id="hvac-modes" class="chip-group"></div>
+          </div>
+          <div class="field">
+            <label class="label" for="away-mode">
+              <input id="away-mode" type="checkbox" />Away mode enabled
+            </label>
+          </div>
+        </form>
+        <div class="log">
+          <h3>Service log</h3>
+          <ul id="service-log"></ul>
+        </div>
+        <div class="state-viewer">
+          <h3>Entity payload</h3>
+          <pre id="state-json"></pre>
+        </div>
+      </section>
+    </main>
+    <footer>
+      Open this file directly in your browser or serve the repository locally. No internet
+      connection is required.
+    </footer>
+    <script type="module" src="./app.js"></script>
+  </body>
+</html>

--- a/sandbox/mock-hass.js
+++ b/sandbox/mock-hass.js
@@ -1,0 +1,174 @@
+const DEFAULT_CLIMATE_ENTITY = 'climate.mock_thermostat';
+
+const DEFAULT_STATES = {
+  [DEFAULT_CLIMATE_ENTITY]: {
+    entity_id: DEFAULT_CLIMATE_ENTITY,
+    state: 'heat',
+    attributes: {
+      friendly_name: 'Mock Thermostat',
+      min_temp: 15,
+      max_temp: 30,
+      current_temperature: 21.5,
+      temperature: 22,
+      target_temp_low: 20,
+      target_temp_high: 24,
+      hvac_modes: ['off', 'heat', 'cool', 'heat_cool', 'auto'],
+      preset_mode: 'none',
+      away_mode: 'off',
+      supported_features: 1,
+      unit_of_measurement: '°C',
+    },
+  },
+};
+
+const NUMERIC_KEYS = new Set([
+  'min_temp',
+  'max_temp',
+  'current_temperature',
+  'temperature',
+  'target_temp_low',
+  'target_temp_high',
+]);
+
+function cloneState(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function toNumberOrNull(value) {
+  if (value === '' || value === null || value === undefined) {
+    return null;
+  }
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+}
+
+export class MockHass {
+  constructor(initialStates = DEFAULT_STATES) {
+    this._initialState = cloneState(initialStates);
+    this.states = cloneState(initialStates);
+    this._listeners = new Set();
+    this._serviceLog = [];
+    this._nextLogId = 1;
+  }
+
+  subscribe(callback) {
+    this._listeners.add(callback);
+    return () => this._listeners.delete(callback);
+  }
+
+  reset() {
+    this.states = cloneState(this._initialState);
+    this._serviceLog = [];
+    this._notify();
+  }
+
+  updateEntity(entityId, update) {
+    const entity = this.states[entityId];
+    if (!entity) {
+      console.warn(`MockHass: cannot update unknown entity "${entityId}"`);
+      return;
+    }
+
+    const { state, attributes } = update || {};
+
+    if (state !== undefined) {
+      entity.state = state;
+    }
+
+    if (attributes) {
+      const mergedAttributes = { ...entity.attributes };
+      Object.entries(attributes).forEach(([key, value]) => {
+        if (NUMERIC_KEYS.has(key) || typeof mergedAttributes[key] === 'number') {
+          mergedAttributes[key] = toNumberOrNull(value);
+        } else {
+          mergedAttributes[key] = value;
+        }
+      });
+      entity.attributes = mergedAttributes;
+    }
+
+    this._notify();
+  }
+
+  callService(domain, service, data = {}) {
+    const entry = {
+      id: this._nextLogId++,
+      timestamp: new Date().toISOString(),
+      domain,
+      service,
+      data: { ...data },
+    };
+    this._serviceLog.unshift(entry);
+    this._serviceLog = this._serviceLog.slice(0, 15);
+
+    if (domain === 'climate') {
+      this._handleClimateService(service, data);
+    }
+
+    this._notify();
+  }
+
+  _handleClimateService(service, data) {
+    const entity = this.states[data.entity_id];
+    if (!entity) {
+      console.warn(`MockHass: cannot handle service for unknown entity "${data.entity_id}"`);
+      return false;
+    }
+
+    let updated = false;
+
+    switch (service) {
+      case 'set_temperature': {
+        if (data.temperature !== undefined) {
+          const value = toNumberOrNull(data.temperature);
+          entity.attributes.temperature = value;
+          if (value !== null) {
+            entity.attributes.target_temp_low = value;
+            entity.attributes.target_temp_high = value;
+          }
+          updated = true;
+        }
+        if (data.target_temp_low !== undefined) {
+          entity.attributes.target_temp_low = toNumberOrNull(data.target_temp_low);
+          updated = true;
+        }
+        if (data.target_temp_high !== undefined) {
+          entity.attributes.target_temp_high = toNumberOrNull(data.target_temp_high);
+          updated = true;
+        }
+        break;
+      }
+      case 'set_hvac_mode': {
+        if (data.hvac_mode !== undefined) {
+          const mode = String(data.hvac_mode);
+          entity.state = mode;
+          if (
+            Array.isArray(entity.attributes.hvac_modes) &&
+            !entity.attributes.hvac_modes.includes(mode)
+          ) {
+            entity.attributes.hvac_modes = [...entity.attributes.hvac_modes, mode];
+          }
+          updated = true;
+        }
+        break;
+      }
+      default:
+        console.warn(`MockHass: unsupported climate service "${service}"`);
+    }
+    return updated;
+  }
+
+  _notify() {
+    this._listeners.forEach((callback) => callback(this));
+  }
+
+  get serviceLog() {
+    return [...this._serviceLog];
+  }
+}
+
+export function createMockHass(states = DEFAULT_STATES) {
+  return new MockHass(states);
+}
+
+export { DEFAULT_CLIMATE_ENTITY };


### PR DESCRIPTION
## Summary
- add an offline sandbox page that loads the thermostat card with a mocked Home Assistant API
- implement a lightweight MockHass class and UI controls for tweaking entity state and observing service calls
- document how to use the sandbox in the README

## Testing
- python3 -m http.server 8000


------
https://chatgpt.com/codex/tasks/task_e_68d2d8a4337c8325b5d609035b0f23ff