### PR TITLE
Restore angle delta helper for pointer rotation

### DIFF
--- a/thermostat_card.lib.js
+++ b/thermostat_card.lib.js
@@ -1505,6 +1505,20 @@ if (!ThermostatUI.prototype.__codexEnhanced) {
     return 0.5;
   };
 
+  ThermostatUI.prototype._angleDelta = function(current, last, arc) {
+    if (!Number.isFinite(current) || !Number.isFinite(last)) {
+      return 0;
+    }
+    const span = Number.isFinite(arc) && arc > CODEX_EPSILON ? arc : 360;
+    let delta = current - last;
+    if (delta > span / 2) {
+      delta -= span;
+    } else if (delta < -span / 2) {
+      delta += span;
+    }
+    return delta;
+  };
+
   ThermostatUI.prototype._hasSetpointChanged = function(snapshot) {
     if (!snapshot) {
       return true;


### PR DESCRIPTION
## Summary
- add a ThermostatUI._angleDelta helper to mirror the previous inline delta logic and prevent rotation errors when dragging the dial

## Testing
- not run (sandbox testing unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68dc9e639d0883259b47757ca23ccce1