### PR TITLE
Add embedded Lovelace card support to figma-carousel-control-card with tests and docs

### DIFF
--- a/tests/vacuum-embedded.spec.js
+++ b/tests/vacuum-embedded.spec.js
@@ -1,0 +1,98 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const vacuumCardSource = fs.readFileSync(path.join(__dirname, '..', 'vacuum_ccard', 'main.js'), 'utf8');
+
+test('embedded button toggles a full-area Dreame card overlay and back', async ({ page }) => {
+  await page.setContent('<!doctype html><html><body></body></html>');
+
+  await page.evaluate(() => {
+    class HaIcon extends HTMLElement {}
+    class HaCard extends HTMLElement {}
+    class DreameVacuumCard extends HTMLElement {
+      connectedCallback() {
+        this.innerHTML = '<button data-testid="dreame-input" style="width:100%;height:100%">Dreame Input</button>';
+        this.querySelector('[data-testid="dreame-input"]')?.addEventListener('click', () => {
+          window.__dreameInputClicks = (window.__dreameInputClicks || 0) + 1;
+        });
+      }
+    }
+    customElements.define('ha-icon', HaIcon);
+    customElements.define('ha-card', HaCard);
+    customElements.define('dreame-vacuum-card', DreameVacuumCard);
+
+    window.__createdCards = 0;
+    window.__lastCreatedType = '';
+    window.__dreameInputClicks = 0;
+    window.loadCardHelpers = async () => ({
+      createCardElement(config) {
+        if (config.type === 'custom:dreame-vacuum-card') {
+          window.__createdCards += 1;
+          window.__lastCreatedType = config.type;
+          const el = document.createElement('dreame-vacuum-card');
+          el.setConfig = () => {};
+          return el;
+        }
+        return null;
+      },
+    });
+  });
+
+  await page.addScriptTag({ content: vacuumCardSource });
+
+  await page.evaluate(() => {
+    const card = document.createElement('figma-carousel-control-card');
+    card.setConfig({
+      sensors: [{ entity: 'sensor.vacuum_battery', name: 'Battery' }],
+      actions: [{ entity: 'vacuum.robot' }],
+      buttons: [{ entity: 'select.vacuum_mode' }],
+      images: ['/local/vacuum/mode.gif'],
+      embedded_button: {
+        label: 'Open map',
+        icon: 'mdi:map-search',
+        close_label: 'Back',
+        close_icon: 'mdi:arrow-left',
+      },
+      embedded_card: {
+        type: 'custom:dreame-vacuum-card',
+        entity: 'vacuum.robot',
+      },
+    });
+    card.hass = {
+      states: {
+        'sensor.vacuum_battery': { state: '88', attributes: { unit_of_measurement: '%', friendly_name: 'Battery' } },
+        'vacuum.robot': { state: 'docked', attributes: { friendly_name: 'Robot' } },
+        'select.vacuum_mode': { state: 'Standard', attributes: { options: ['Quiet', 'Standard', 'Turbo'] } },
+      },
+      callService: () => {},
+    };
+    document.body.appendChild(card);
+  });
+
+  const card = page.locator('figma-carousel-control-card');
+  const openButton = card.locator('.embedded-toggle-host [data-embedded-toggle]');
+  await expect(openButton).toBeVisible();
+  await openButton.click();
+
+  const embeddedLayer = card.locator('[data-embedded-layer]');
+  await expect(embeddedLayer).toBeVisible();
+  await expect(card.locator('.content')).toHaveClass(/embedded-open/);
+  await expect.poll(async () => card.evaluate((el) => (el.shadowRoot?.querySelector('[data-embedded-host]')?.childElementCount ?? 0))).toBeGreaterThan(0);
+  await expect(card.locator('.embedded-toolbar [data-embedded-toggle] span')).toHaveText('Back');
+
+  await card.evaluate((el) => {
+    const button = el.shadowRoot?.querySelector('dreame-vacuum-card [data-testid="dreame-input"]');
+    if (!(button instanceof HTMLElement)) throw new Error('Embedded input button not found');
+    button.click();
+  });
+
+  const [createdCards, lastCreatedType, inputClicks] = await page.evaluate(() => [window.__createdCards, window.__lastCreatedType, window.__dreameInputClicks]);
+  expect(createdCards).toBe(1);
+  expect(lastCreatedType).toBe('custom:dreame-vacuum-card');
+  expect(inputClicks).toBe(1);
+
+  await card.locator('.embedded-toolbar [data-embedded-toggle]').click();
+  await expect(card.locator('[data-embedded-layer]')).toHaveCount(0);
+  await expect(card.locator('.content')).not.toHaveClass(/embedded-open/);
+});

--- a/vacuum_ccard/README.md
+++ b/vacuum_ccard/README.md
@@ -17,9 +17,41 @@ buttons:
 images:
   - /local/vacuum/mode.gif
   - /local/vacuum/boost.gif
+embedded_button:
+  label: Open map
+  icon: mdi:map-search
+  close_icon: mdi:arrow-left
+  close_label: Back to controls
+embedded_card:
+  type: map
+  entities:
+    - device_tracker.robot_vacuum
+  hours_to_show: 6
+```
+
+
+### Example: embed dreame-vacuum card
+
+```yaml
+type: custom:figma-carousel-control-card
+buttons:
+  - entity: select.dreame_cleaning_mode
+images:
+  - /local/vacuum/idle.png
+embedded_button:
+  label: Open Dreame map
+  icon: mdi:map
+  close_label: Back
+  close_icon: mdi:arrow-left
+embedded_card:
+  type: custom:dreame-vacuum-card
+  entity: vacuum.dreame_l10s_ultra
+  map_key: map
 ```
 
 ## Notes
 - No carousel auto-advance.
 - Image slide transition is left-to-right style with ~1.2s duration.
 - Options overlay is transparent and option buttons are subtle/outlined.
+- `embedded_button` is optional; when configured with `embedded_card`, clicking it replaces the preview/menu area with a full-size Lovelace card container.
+- Embedded card area now captures click/touch input directly so interactive cards (like `custom:dreame-vacuum-card`) remain fully usable.

--- a/vacuum_ccard/main.js
+++ b/vacuum_ccard/main.js
@@ -15,14 +15,34 @@ class FigmaCarouselControlCard extends HTMLElement {
     this._hass = null;
     this._activeButtonIndex = 0;
     this._showOptions = false;
+    this._showEmbeddedCard = false;
+    this._embeddedCardEl = null;
+    this._embeddedCardConfigKey = "";
     this._rendered = false;
   }
 
   setConfig(config) {
-    this._config = { sensors: [], actions: [], buttons: [], images: [], ...config };
+    this._config = {
+      sensors: [],
+      actions: [],
+      buttons: [],
+      images: [],
+      embedded_card: null,
+      embedded_button: { label: "Open card", icon: "mdi:open-in-new" },
+      ...config,
+    };
     ["sensors", "actions", "buttons", "images"].forEach((k) => {
       if (!Array.isArray(this._config[k])) throw new Error(`${k} must be a list`);
     });
+    if (this._config.embedded_card && typeof this._config.embedded_card !== "object") {
+      throw new Error("embedded_card must be a card configuration object");
+    }
+    if (this._config.embedded_button && typeof this._config.embedded_button !== "object") {
+      throw new Error("embedded_button must be an object");
+    }
+    this._showEmbeddedCard = false;
+    this._embeddedCardEl = null;
+    this._embeddedCardConfigKey = JSON.stringify(this._config.embedded_card || null);
     this._activeButtonIndex = Math.min(this._activeButtonIndex, Math.max(0, this._config.buttons.length - 1));
     this._rendered = false;
     this._render();
@@ -120,6 +140,57 @@ class FigmaCarouselControlCard extends HTMLElement {
     return `<div class="carousel"><div class="track">${slides}</div><div class="overlay-host"></div><div class="dots">${images.map((_, i) => `<button class="dot" data-dot="${i}"></button>`).join("")}</div></div>`;
   }
 
+  _embeddedToggleMarkup() {
+    if (!this._config.embedded_card) return "";
+    const isBack = this._showEmbeddedCard;
+    const icon = isBack
+      ? (this._config.embedded_button?.close_icon || "mdi:arrow-left")
+      : (this._config.embedded_button?.icon || "mdi:open-in-new");
+    const label = isBack
+      ? (this._config.embedded_button?.close_label || "Back")
+      : (this._config.embedded_button?.label || "Open card");
+    return `<button class="embedded-toggle" data-embedded-toggle><ha-icon icon="${escapeHtml(icon)}"></ha-icon><span>${escapeHtml(label)}</span></button>`;
+  }
+
+  _embeddedCardMarkup() {
+    if (!this._showEmbeddedCard) return "";
+    return `<div class="embedded-layer" data-embedded-layer>
+      <div class="embedded-card-host" data-embedded-host></div>
+      <div class="embedded-toolbar">${this._embeddedToggleMarkup()}</div>
+    </div>`;
+  }
+
+  async _ensureEmbeddedCard() {
+    if (!this.shadowRoot || !this._showEmbeddedCard || !this._config.embedded_card) return;
+    const host = this.shadowRoot.querySelector("[data-embedded-host]");
+    if (!host) return;
+    const configKey = JSON.stringify(this._config.embedded_card || null);
+    if (!this._embeddedCardEl || this._embeddedCardConfigKey !== configKey) {
+      this._embeddedCardEl = null;
+      this._embeddedCardConfigKey = configKey;
+      try {
+        const helpers = await window.loadCardHelpers?.();
+        this._embeddedCardEl = helpers?.createCardElement
+          ? helpers.createCardElement(this._config.embedded_card)
+          : null;
+      } catch (err) {
+        this._embeddedCardEl = null;
+      }
+      if (!this._embeddedCardEl) {
+        const fallback = document.createElement("div");
+        fallback.textContent = "Unable to render embedded card.";
+        fallback.classList.add("embedded-error");
+        this._embeddedCardEl = fallback;
+      } else if (this._embeddedCardEl.setConfig) {
+        this._embeddedCardEl.setConfig(this._config.embedded_card);
+      }
+      this._embeddedCardEl.classList.add("embedded-card");
+    }
+    if (this._hass) this._embeddedCardEl.hass = this._hass;
+    host.innerHTML = "";
+    host.appendChild(this._embeddedCardEl);
+  }
+
   _applyInteractiveState() {
     if (!this.shadowRoot) return;
     const track = this.shadowRoot.querySelector('.track');
@@ -141,6 +212,27 @@ class FigmaCarouselControlCard extends HTMLElement {
         this._applyInteractiveState();
       }));
     }
+    const content = this.shadowRoot.querySelector('.content');
+    if (content) content.classList.toggle('embedded-open', this._showEmbeddedCard);
+    const embeddedRoot = this.shadowRoot.querySelector('.embedded-root');
+    if (embeddedRoot) {
+      embeddedRoot.style.pointerEvents = this._showEmbeddedCard ? 'auto' : 'none';
+      embeddedRoot.innerHTML = this._embeddedCardMarkup();
+      embeddedRoot.querySelectorAll('[data-embedded-toggle]').forEach((el) => el.addEventListener('click', () => {
+        this._showEmbeddedCard = !this._showEmbeddedCard;
+        this._applyInteractiveState();
+      }));
+      this._ensureEmbeddedCard();
+    }
+    const embeddedToggleHost = this.shadowRoot.querySelector('.embedded-toggle-host');
+    if (embeddedToggleHost) {
+      embeddedToggleHost.innerHTML = this._showEmbeddedCard ? "" : this._embeddedToggleMarkup();
+      embeddedToggleHost.querySelectorAll('[data-embedded-toggle]').forEach((el)=>el.addEventListener('click',()=>{
+        this._showEmbeddedCard = !this._showEmbeddedCard;
+        this._showOptions = false;
+        this._applyInteractiveState();
+      }));
+    }
   }
 
   _refreshDynamicData() {
@@ -155,6 +247,7 @@ class FigmaCarouselControlCard extends HTMLElement {
       const state = this._entityState(b.entity)?.state || 'Unavailable';
       meta.textContent = `${this._buttonOptions(b.entity).length} options • ${state}`;
     });
+    if (this._embeddedCardEl && this._hass) this._embeddedCardEl.hass = this._hass;
   }
 
   _bindEvents() {
@@ -178,7 +271,15 @@ class FigmaCarouselControlCard extends HTMLElement {
       .actions{padding:12px;display:flex;gap:8px;flex-wrap:wrap;background:rgba(255,255,255,.08);border-top:1px solid rgba(255,255,255,.14)}
       .action-btn{position:relative;overflow:hidden;border:1px solid rgba(255,255,255,.3);color:#fff;padding:10px 12px;border-radius:10px;font-weight:600;backdrop-filter:blur(8px)}
       .a1{background:rgba(34,197,94,.65)}.a2{background:rgba(234,179,8,.65)}.a3{background:rgba(239,68,68,.65)}.a4{background:rgba(59,130,246,.65)}.a5{background:rgba(168,85,247,.65)}.a6{background:rgba(6,182,212,.65)}
-      .content{display:flex;min-height:340px}.left{width:42%;padding:12px}.right{flex:1;padding:12px}
+      .content{position:relative;display:flex;min-height:340px}.left{width:42%;padding:12px}.right{flex:1;padding:12px}
+      .content.embedded-open .left,.content.embedded-open .right{visibility:hidden;pointer-events:none}
+      .embedded-root{position:absolute;inset:0;z-index:5}
+      .embedded-layer{position:absolute;inset:0;background:rgba(17,24,39,.8);backdrop-filter:blur(10px);overflow:hidden}
+      .embedded-toolbar{position:absolute;top:12px;right:12px;z-index:2;pointer-events:auto}
+      .embedded-card-host{position:absolute;inset:0;display:flex;min-height:0;pointer-events:auto;touch-action:auto}
+      .embedded-card{width:100%;height:100%;display:block;pointer-events:auto;touch-action:auto}
+      .embedded-card > *{width:100%;height:100%;pointer-events:auto;touch-action:auto}
+      .embedded-error{width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(255,255,255,.1);border:1px solid rgba(255,255,255,.25);border-radius:12px;color:#fff}
       .carousel{position:relative;height:100%;border-radius:12px;overflow:hidden;background:rgba(0,0,0,.2)}
       .track{display:flex;height:100%;--idx:${this._activeButtonIndex};transform:translate3d(calc(var(--idx) * -100%),0,0);transition:transform 1.25s cubic-bezier(.22,.61,.36,1)}
       .slide{min-width:100%;height:100%}.img{width:100%;height:100%;object-fit:cover;transition:filter .35s ease}
@@ -190,6 +291,8 @@ class FigmaCarouselControlCard extends HTMLElement {
       .menu-btn{position:relative;overflow:hidden;background:linear-gradient(135deg,rgba(255,255,255,.92),rgba(226,232,240,.95));border:1px solid rgba(17,24,39,.45);color:#111827;padding:14px;border-radius:12px;text-align:left;backdrop-filter:blur(8px)}
       .menu-btn.active{outline:2px solid rgba(17,24,39,.6)}
       .menu-btn small{opacity:.9;color:#1f2937}
+      .embedded-toggle{display:flex;align-items:center;gap:8px;margin-top:10px;width:100%;justify-content:center;padding:11px 12px;border-radius:12px;font-weight:600;color:#fff;background:rgba(59,130,246,.72);border:1px solid rgba(255,255,255,.32)}
+      .embedded-toolbar .embedded-toggle{margin-top:0;width:auto;min-width:120px}
       .shine{position:absolute;inset:0;transform:translateX(-200%);background:linear-gradient(90deg,transparent,rgba(255,255,255,.25),transparent);transition:transform .7s ease}
       .menu-btn:hover .shine,.action-btn:hover .shine{transform:translateX(200%)}
       .dots{position:absolute;left:0;right:0;bottom:10px;display:flex;justify-content:center;gap:8px}.dot{width:8px;height:8px;border:none;border-radius:999px;background:rgba(255,255,255,.5)}.dot.active{width:18px;background:#fff}
@@ -198,7 +301,11 @@ class FigmaCarouselControlCard extends HTMLElement {
     <ha-card>
       <div class="status">${this._sensorMarkup()}</div>
       <div class="actions">${this._actionsMarkup()}</div>
-      <div class="content"><div class="left">${this._carouselMarkup()}</div><div class="right"><div class="menu">${this._menuMarkup()}</div></div></div>
+      <div class="content">
+        <div class="left">${this._carouselMarkup()}</div>
+        <div class="right"><div class="menu">${this._menuMarkup()}</div><div class="embedded-toggle-host"></div></div>
+        <div class="embedded-root"></div>
+      </div>
     </ha-card>`;
 
     this._bindEvents();


### PR DESCRIPTION
### Motivation

- Enable an optional embedded Lovelace card area that replaces the preview/menu region so interactive cards can be displayed full-area (for example `custom:dreame-vacuum-card`).

### Description

- Implement embedded card support in `vacuum_ccard/main.js` by adding state (`_showEmbeddedCard`, `_embeddedCardEl`, `_embeddedCardConfigKey`), new markup helpers (`_embeddedToggleMarkup`, `_embeddedCardMarkup`), and a loader/renderer `_ensureEmbeddedCard` that uses `window.loadCardHelpers` to create the embedded card element. 
- Wire the embedded UI into render/update flows by updating `_applyInteractiveState`, `_refreshDynamicData`, and `_render` to include the embedded root, toolbar toggle, CSS rules, and pointer-event handling so embedded cards receive input. 
- Add validation and sensible defaults for `embedded_card` and `embedded_button` in `setConfig`. 
- Update `vacuum_ccard/README.md` with configuration examples and notes about the new `embedded_button`/`embedded_card` options and an example for embedding a `custom:dreame-vacuum-card`. 
- Add an end-to-end Playwright test `tests/vacuum-embedded.spec.js` that mounts the card, toggles the embedded view, verifies the embedded host is populated, exercises an embedded control, and toggles back.

### Testing

- Added and ran the Playwright spec `tests/vacuum-embedded.spec.js`, which verifies opening and closing the embedded layer and that an interactive embedded card receives clicks, and the test passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb55d516d88325820345be297c1c03)